### PR TITLE
Ability to watch Files / Folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ require("vulcanize?compress=true&base=/lib!./imports.html");
 // => returns i. e. "/lib/imports.html"
 ```
 
+* To watch files for changes, use a `|` separated list of relative filenames
+* To watch folders for changes, use a `|` separated list of relative directories
+
+``` javascript
+require("vulcanize?compress=true&base=/lib&watchFolders=./elements|./elements2&watchFiles=./elements3/a.html|./elements3/b.html!./imports.html");
+// => returns i. e. "/lib/imports.html"
+//    rebuilds when any file in ./elements or ./elements2 changes
+//    rebuilds when ./elements3/a.html or ./elements3/b.html changes
+```
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/src/loader.js
+++ b/src/loader.js
@@ -34,7 +34,7 @@ module.exports = async function main(content) {
   const query = loaderUtils.parseQuery(this.query);
 
   // pathname :: String -> String
-  const pathname = (format = '[path][name].[ext]') => loaderUtils.interpolateName(this, format, {});
+  const pathname = (format = '[path][name].[ext]') => path.normalize(loaderUtils.interpolateName(this, format, {}));
 
   // emitFile :: String -> String
   const emitFile = (url, content) => this.emitFile(url, content)
@@ -68,6 +68,27 @@ module.exports = async function main(content) {
 
   // addDependency :: String -> IO
   const addDependency = (relativePath) => this.dependency(pathname('[path]' + relativePath))
+
+  // addContextDependency :: String -> IO
+  const addContextDependency = (relativePath) => this.addContextDependency(pathname('[path]' + relativePath))
+
+  // watchFiles :: IO
+  const watchFiles = () => {
+    if (query.watchFiles){
+      for (let f of query.watchFiles.split("|")){
+        addDependency(f);
+      }
+    }
+  }
+
+  // watchFolders :: IO
+  const watchFolders = () => {
+    if (query.watchFolders){
+      for (let f of query.watchFolders.split("|")){
+        addContextDependency(f);
+      }
+    }
+  }
 
   // vulcanizedContent :: String -> Maybe String
   const vulcanizeContent = async (content) => {
@@ -118,6 +139,8 @@ module.exports = async function main(content) {
       let crisped = vulcanized.map(crisp)
       let html = crisped.map(compose(htmlCode, prop('html')))
       let js = crisped.map(compose(transformJS, prop('js')))
+      watchFiles()
+      watchFolders()
       emitFiles(js.get(), html.get())
       return {js, html}
     } catch(e) {


### PR DESCRIPTION
Thanks for the nice loader.  This PR adds file/folder watching so that vulcanize will re-run when elements change.  Example syntax:

* To watch files for changes, use a `|` separated list of relative filenames
* To watch folders for changes, use a `|` separated list of relative directories

``` javascript
require("vulcanize?compress=true&base=/lib&watchFolders=./elements|./elements2&watchFiles=./elements3/a.html|./elements3/b.html!./imports.html");
// => returns i. e. "/lib/imports.html"
//    rebuilds when any file in ./elements or ./elements2 changes
//    rebuilds when ./elements3/a.html or ./elements3/b.html changes
```

You can try out the package by changing your `packages.json`:

`"vulcanize-loader": "git+https://github.com/caleblloyd/vulcanize-loader#transpiled"`