### PR TITLE
Use webpack output.publicPath configuration

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -266,12 +266,13 @@ module.exports = function () {
               try {
                 options = JSON.parse(_fs2.default.readFileSync(_path2.default.resolve(process.cwd(), '.babelrc'), 'utf-8'));
               } catch (e) {
-                options = { compact: false };
+                options = { compact: false, presets: ['es2015'] };
               }
               return options;
             }();
 
             // babelCode :: String -> String
+
 
             babelCode = function babelCode(content) {
               return es6 ? babel.transform(content, babelRc).code : content;
@@ -351,12 +352,12 @@ module.exports = function () {
             // finalUrl :: String
 
 
-            finalUrl = (query.base || '') + '/' + pathname('[name].[ext]');
+            finalUrl = (query.base ? query.base + '/' : '') + pathname('[name].[ext]');
 
             // webpackModuleResult :: String -> String
 
             webpackModuleResult = function webpackModuleResult(url) {
-              return ['\t\t\t', 'var link = document.createElement(\'link\');', 'link.rel = \'import\';', 'link.href = ' + JSON.stringify(finalUrl) + ';', 'document.head.appendChild(link)'].join('\n\t\t\t');
+              return ['\t\t\t', 'var link = document.createElement(\'link\');', 'link.rel = \'import\';', 'link.href = __webpack_public_path__ + ' + JSON.stringify(finalUrl) + ';', 'document.head.appendChild(link)'].join('\n\t\t\t');
             };
 
             // ---------------------

--- a/src/loader.js
+++ b/src/loader.js
@@ -119,7 +119,7 @@ module.exports = async function main(content) {
       try {
           options = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), '.babelrc'), 'utf-8'))
       } catch(e) {
-          options = {compact: false}
+          options = {compact: false, presets: ['es2015']}
       }
       return options
   })()
@@ -162,7 +162,7 @@ module.exports = async function main(content) {
   }
 
   // finalUrl :: String
-  const finalUrl = (query.base || '') + '/' + pathname('[name].[ext]')
+  const finalUrl = (query.base ? query.base + '/' : '') + pathname('[name].[ext]')
 
   // webpackModuleResult :: String -> String
   const webpackModuleResult = (url) => (
@@ -170,7 +170,7 @@ module.exports = async function main(content) {
       '\t\t\t',
       'var link = document.createElement(\'link\');',
       'link.rel = \'import\';',
-      'link.href = ' + JSON.stringify(finalUrl) + ';',
+      'link.href = __webpack_public_path__ + ' + JSON.stringify(finalUrl) + ';',
       'document.head.appendChild(link)',
       // 'module.exports = __webpack_public_path__ + ' + JSON.stringify(url),
     ].join('\n\t\t\t')


### PR DESCRIPTION
- Fixes #8 
- Also fixes default babelRc that was [causing an exception in uglifyjs](https://github.com/aitoroses/vulcanize-loader/commit/dad4c80ff53ce6c6cc65821de9f26f7060578be1#diff-7c7d4918b118d27d18538f53b8155e88R269)